### PR TITLE
[iOS] 메뉴 상세화면과 기능 구현 

### DIFF
--- a/iOS/SideDishApp/SideDishApp.xcodeproj/project.pbxproj
+++ b/iOS/SideDishApp/SideDishApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3008E7752454923C00E3EAF2 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3008E7742454923C00E3EAF2 /* DetailViewController.swift */; };
 		307EE45D2451C5B6004C6A29 /* SectionHeaderTapGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 307EE45C2451C5B6004C6A29 /* SectionHeaderTapGestureRecognizer.swift */; };
 		30955F8A24531533004D8940 /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30955F8924531533004D8940 /* ImageCache.swift */; };
 		30C18E32245406D00087F83E /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30C18E31245406D00087F83E /* ImageLoader.swift */; };
@@ -31,6 +32,7 @@
 
 /* Begin PBXFileReference section */
 		11121757DA479AE946A24C42 /* Pods-SideDishApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SideDishApp.release.xcconfig"; path = "Target Support Files/Pods-SideDishApp/Pods-SideDishApp.release.xcconfig"; sourceTree = "<group>"; };
+		3008E7742454923C00E3EAF2 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		307EE45C2451C5B6004C6A29 /* SectionHeaderTapGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeaderTapGestureRecognizer.swift; sourceTree = "<group>"; };
 		30955F8924531533004D8940 /* ImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
 		30C18E31245406D00087F83E /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
@@ -154,6 +156,7 @@
 			children = (
 				30E2F0C9244DBEFA00E45C03 /* MenuViewController.swift */,
 				30E2F0D9244DC8C100E45C03 /* LoginViewController.swift */,
+				3008E7742454923C00E3EAF2 /* DetailViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -292,6 +295,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				30F2E9AD244EDCDE00C8D289 /* AllMenu.swift in Sources */,
+				3008E7752454923C00E3EAF2 /* DetailViewController.swift in Sources */,
 				307EE45D2451C5B6004C6A29 /* SectionHeaderTapGestureRecognizer.swift in Sources */,
 				30955F8A24531533004D8940 /* ImageCache.swift in Sources */,
 				30F2E9AA244ECBDD00C8D289 /* NetworkUseCase.swift in Sources */,

--- a/iOS/SideDishApp/SideDishApp.xcodeproj/project.pbxproj
+++ b/iOS/SideDishApp/SideDishApp.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		3008E7752454923C00E3EAF2 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3008E7742454923C00E3EAF2 /* DetailViewController.swift */; };
+		3008E79D24557B3B00E3EAF2 /* DescriptionLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3008E79C24557B3B00E3EAF2 /* DescriptionLabel.swift */; };
+		3008E79F24557CD800E3EAF2 /* ContentsTitleLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3008E79E24557CD800E3EAF2 /* ContentsTitleLabel.swift */; };
 		307EE45D2451C5B6004C6A29 /* SectionHeaderTapGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 307EE45C2451C5B6004C6A29 /* SectionHeaderTapGestureRecognizer.swift */; };
 		30955F8A24531533004D8940 /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30955F8924531533004D8940 /* ImageCache.swift */; };
 		30C18E32245406D00087F83E /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30C18E31245406D00087F83E /* ImageLoader.swift */; };
@@ -33,6 +35,8 @@
 /* Begin PBXFileReference section */
 		11121757DA479AE946A24C42 /* Pods-SideDishApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SideDishApp.release.xcconfig"; path = "Target Support Files/Pods-SideDishApp/Pods-SideDishApp.release.xcconfig"; sourceTree = "<group>"; };
 		3008E7742454923C00E3EAF2 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
+		3008E79C24557B3B00E3EAF2 /* DescriptionLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DescriptionLabel.swift; sourceTree = "<group>"; };
+		3008E79E24557CD800E3EAF2 /* ContentsTitleLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentsTitleLabel.swift; sourceTree = "<group>"; };
 		307EE45C2451C5B6004C6A29 /* SectionHeaderTapGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeaderTapGestureRecognizer.swift; sourceTree = "<group>"; };
 		30955F8924531533004D8940 /* ImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
 		30C18E31245406D00087F83E /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
@@ -176,6 +180,8 @@
 				30F6A186244DD90700EAD976 /* MenuTableViewCell.swift */,
 				30CB3DC1245021710022C15E /* MenuHeaderView.swift */,
 				307EE45C2451C5B6004C6A29 /* SectionHeaderTapGestureRecognizer.swift */,
+				3008E79C24557B3B00E3EAF2 /* DescriptionLabel.swift */,
+				3008E79E24557CD800E3EAF2 /* ContentsTitleLabel.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -297,6 +303,7 @@
 				30F2E9AD244EDCDE00C8D289 /* AllMenu.swift in Sources */,
 				3008E7752454923C00E3EAF2 /* DetailViewController.swift in Sources */,
 				307EE45D2451C5B6004C6A29 /* SectionHeaderTapGestureRecognizer.swift in Sources */,
+				3008E79D24557B3B00E3EAF2 /* DescriptionLabel.swift in Sources */,
 				30955F8A24531533004D8940 /* ImageCache.swift in Sources */,
 				30F2E9AA244ECBDD00C8D289 /* NetworkUseCase.swift in Sources */,
 				30F2E9A8244EC2F800C8D289 /* NetworkManager.swift in Sources */,
@@ -308,6 +315,7 @@
 				30C18E32245406D00087F83E /* ImageLoader.swift in Sources */,
 				30E2F0C6244DBEFA00E45C03 /* AppDelegate.swift in Sources */,
 				30EF1611244EAD290074E4A4 /* MenuTableView.swift in Sources */,
+				3008E79F24557CD800E3EAF2 /* ContentsTitleLabel.swift in Sources */,
 				30F2E9A6244EC05C00C8D289 /* NetworkErrorCase.swift in Sources */,
 				30E2F0C8244DBEFA00E45C03 /* SceneDelegate.swift in Sources */,
 				30F2E9A4244EBFED00C8D289 /* NetworkSetting.swift in Sources */,

--- a/iOS/SideDishApp/SideDishApp/Base.lproj/Main.storyboard
+++ b/iOS/SideDishApp/SideDishApp/Base.lproj/Main.storyboard
@@ -32,7 +32,7 @@
                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </state>
                                 <connections>
-                                    <action selector="signInGithub:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1Nk-UO-Xen"/>
+                                    <action selector="signInGithub:" destination="BYZ-38-t0r" eventType="touchUpInside" id="GTh-NQ-eSL"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -46,7 +46,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="140.57971014492756" y="138.61607142857142"/>
+            <point key="canvasLocation" x="1933" y="136"/>
         </scene>
         <!--Menu View Controller-->
         <scene sceneID="9tn-TA-0Lz">
@@ -60,11 +60,11 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="832"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="MenuTableViewCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="MenuTableViewCell" id="myY-i9-Bej" customClass="MenuTableViewCell" customModule="SideDishApp" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="MenuTableViewCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="MenuTableViewCell" id="myY-i9-Bej" customClass="MenuTableViewCell" customModule="SideDishApp" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="28" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="myY-i9-Bej" id="1jE-Nz-c0P">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="383" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -87,24 +87,40 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="OCZ-bO-cuf" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1989.8550724637682" y="135.9375"/>
+            <point key="canvasLocation" x="3808.6956521739135" y="135.9375"/>
+        </scene>
+        <!--Detail View Controller-->
+        <scene sceneID="W7b-xC-uKj">
+            <objects>
+                <viewController storyboardIdentifier="DetailViewController" id="gP7-dc-Qc2" customClass="DetailViewController" customModule="SideDishApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="tXG-CJ-hJW">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="nDt-sn-xpA"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="iGn-i0-jfF"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="e8m-mH-iUV" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4694.202898550725" y="138.61607142857142"/>
         </scene>
         <!--Navigation Controller-->
-        <scene sceneID="nkn-6e-tfP">
+        <scene sceneID="zKN-Ac-c85">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" navigationBarHidden="YES" id="iNt-ch-PoO" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="NavigationViewController" automaticallyAdjustsScrollViewInsets="NO" modalPresentationStyle="fullScreen" navigationBarHidden="YES" id="AMg-eU-BPZ" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="z8i-aA-FEc">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="15U-Md-J7E">
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
-                        <segue destination="w6T-z1-2Zc" kind="relationship" relationship="rootViewController" id="0N1-uh-4MW"/>
+                        <segue destination="w6T-z1-2Zc" kind="relationship" relationship="rootViewController" id="obB-Rz-oU5"/>
                     </connections>
                 </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="Q08-vs-jXB" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="p2Z-k0-dTr" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1079.7101449275362" y="135.9375"/>
+            <point key="canvasLocation" x="2898.5507246376815" y="135.9375"/>
         </scene>
     </scenes>
 </document>

--- a/iOS/SideDishApp/SideDishApp/Models/MenuDetail.swift
+++ b/iOS/SideDishApp/SideDishApp/Models/MenuDetail.swift
@@ -10,28 +10,15 @@ import Foundation
 
 struct MenuDetail: Decodable {
     var hash: String
-    var data: MenuDetailData
-}
-
-struct MenuDetailData: Decodable {
+    var title: String
     var top_image: String
-    var thumb_images: [ThumbImage]
-    var product_description: String
+    var thumb_images: [String]
+    var description: String
     var point: String
     var delivery_info: String
     var delivery_fee: String
-    var prices: [Price]
-    var detail_section: [DetailImage]
+    var originPrice: String
+    var salePrice: String
+    var detail_section: [String]
 }
 
-struct ThumbImage: Decodable {
-    var image: String
-}
-
-struct Price: Decodable {
-    var price: String
-}
-
-struct DetailImage: Decodable {
-    var detailImage: String
-}

--- a/iOS/SideDishApp/SideDishApp/Utilities/ImageLoader/ImageLoader.swift
+++ b/iOS/SideDishApp/SideDishApp/Utilities/ImageLoader/ImageLoader.swift
@@ -38,13 +38,7 @@ extension ImageLoader: ImageLoadable {
 }
 
 extension ImageLoader {
-    func requestImage(urlString: String, completion: Handler) {
-        let url = URL(string: urlString)
-        do {
-             let data = try Data(contentsOf: url!)
-            completion(.success(data))
-        } catch {
-            completion(.failure(error))
-        }
+    func requestImage(urlString: String, completion: @escaping Handler) {
+        NetworkUseCase.makeImage(with: MenuViewController.networkManager, urlString: urlString) { completion(.success($0)) }
     }
 }

--- a/iOS/SideDishApp/SideDishApp/Utilities/Networking/NetworkUseCase.swift
+++ b/iOS/SideDishApp/SideDishApp/Utilities/Networking/NetworkUseCase.swift
@@ -44,6 +44,17 @@ struct NetworkUseCase {
         }
     }
     
+    static func makeImage(with manager: NetworkManager, urlString: String, completed: @escaping (Data) -> ()) {
+        manager.getResource(url: urlString, methodType: .get) { result in
+            switch result {
+            case .success(let data):
+                completed(data)
+            case .failure(let error):
+                print(error)
+            }
+        }
+    }
+    
     static func makeStub (with manager: NetworkManager, completed: @escaping(AllMenu) -> ()) {
         MockEndPoints.allCases.forEach { url in
             manager.getResource(url: url.rawValue , methodType: .get, body: nil) { result in

--- a/iOS/SideDishApp/SideDishApp/Utilities/Networking/NetworkUseCase.swift
+++ b/iOS/SideDishApp/SideDishApp/Utilities/Networking/NetworkUseCase.swift
@@ -30,7 +30,8 @@ struct NetworkUseCase {
     }
     
     static func makeMenuDetail(with manager: NetworkManager, menuHash: String, completed: @escaping(MenuDetail) -> ()) {
-        let url = EndPoints.MenuDetail + "/\(menuHash)"
+//        let url = EndPoints.MenuDetail + "/\(menuHash)"
+        let url = "http://www.mocky.io/v2/5ea67ef23200006700ac2a40"
         manager.getResource(url: url, methodType: .get, body: nil) { result in
             switch result {
             case .success(let data):

--- a/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
+++ b/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
@@ -9,9 +9,189 @@
 import UIKit
 
 class DetailViewController: UIViewController {
-
+    
+    //MARK:- properties
+    private let wholeScrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.scrollsToTop = true
+        scrollView.showsVerticalScrollIndicator = true
+        return scrollView
+    }()
+    
+    private let thumbnailScrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.showsHorizontalScrollIndicator = true
+        return scrollView
+    }()
+    
+    private let thumbnailStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.spacing = 0
+        stackView.distribution = .fillEqually
+        stackView.alignment = .center
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    private let menuTitle: UILabel = {
+        let label = UILabel()
+        label.textColor = .black
+        label.font = UIFont.boldSystemFont(ofSize: 17.0)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let menuDescription: UILabel = {
+        let label = UILabel()
+        label.textColor = .black
+        label.font = UIFont.systemFont(ofSize: 15.0)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let priceTitle = ContentsTitleLabel()
+    private let savedMoneyTitle = ContentsTitleLabel()
+    private let deliveryMoneyTitle = ContentsTitleLabel()
+    private let deliveryInfoTitle = ContentsTitleLabel()
+    
+    private let originalPrice = DescriptionLabel()
+    private let savedMoney = DescriptionLabel()
+    private let deliveryMoney = DescriptionLabel()
+    private let deliveryInfo = DescriptionLabel()
+    
+    private let salePrice: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.boldSystemFont(ofSize: 18)
+        label.textColor = #colorLiteral(red: 0.4551282529, green: 0.9278236041, blue: 0.8855857598, alpha: 1)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let detailImageStack: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 0
+        stackView.distribution = .fillEqually
+        stackView.alignment = .center
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    private let orderButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("주문하기", for: .normal)
+        button.setTitleColor(.white, for: .normal)
+        button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 18)
+        button.titleLabel?.textAlignment = .center
+        button.backgroundColor = #colorLiteral(red: 0.4551282529, green: 0.9278236041, blue: 0.8855857598, alpha: 1)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    //MARK:- functions
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.navigationController?.navigationBar.isHidden = false
+        
+        addSubViews()
+        configureConstraints()
+    }
+    
+    func makeImageView(image: UIImage) -> UIImageView {
+        let imageView = UIImageView()
+        imageView.image = image
+        return imageView
+    }
+    
+    private func addSubViews() {
+        self.view.addSubview(wholeScrollView)
+        wholeScrollView.addSubview(thumbnailScrollView)
+        thumbnailScrollView.addSubview(thumbnailStackView)
+        
+        wholeScrollView.addSubview(menuTitle)
+        wholeScrollView.addSubview(menuDescription)
+        
+        wholeScrollView.addSubview(priceTitle)
+        wholeScrollView.addSubview(savedMoneyTitle)
+        wholeScrollView.addSubview(deliveryMoneyTitle)
+        wholeScrollView.addSubview(deliveryInfoTitle)
+        
+        wholeScrollView.addSubview(originalPrice)
+        wholeScrollView.addSubview(savedMoney)
+        wholeScrollView.addSubview(deliveryMoney)
+        wholeScrollView.addSubview(deliveryInfo)
+        wholeScrollView.addSubview(salePrice)
+        
+        wholeScrollView.addSubview(detailImageStack)
+        wholeScrollView.addSubview(orderButton)
+    }
+    
+    private func configureConstraints() {
+        let constraints = [
+            wholeScrollView.topAnchor.constraint(equalTo: self.view.topAnchor),
+            wholeScrollView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            wholeScrollView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            wholeScrollView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+            
+            thumbnailScrollView.topAnchor.constraint(equalTo: self.view.topAnchor),
+            thumbnailScrollView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            thumbnailScrollView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            thumbnailScrollView.heightAnchor.constraint(equalTo: self.view.heightAnchor, multiplier: 0.3),
+            
+            thumbnailStackView.topAnchor.constraint(equalTo: self.view.topAnchor),
+            thumbnailStackView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            thumbnailStackView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            thumbnailStackView.bottomAnchor.constraint(equalTo: thumbnailScrollView.bottomAnchor),
+            
+            menuTitle.topAnchor.constraint(equalTo: thumbnailScrollView.bottomAnchor, constant: 8),
+            menuTitle.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 8),
+            
+            menuDescription.topAnchor.constraint(equalTo: menuTitle.bottomAnchor, constant: 4),
+            menuDescription.leadingAnchor.constraint(equalTo: menuTitle.leadingAnchor),
+            
+            priceTitle.topAnchor.constraint(equalTo: menuDescription.bottomAnchor, constant: 8),
+            priceTitle.leadingAnchor.constraint(equalTo: menuDescription.leadingAnchor),
+            
+            savedMoneyTitle.topAnchor.constraint(equalTo: menuDescription.bottomAnchor, constant: 4),
+            savedMoneyTitle.leadingAnchor.constraint(equalTo: menuDescription.leadingAnchor),
+            
+            deliveryMoneyTitle.topAnchor.constraint(equalTo: menuDescription.bottomAnchor, constant: 4),
+            deliveryMoneyTitle.leadingAnchor.constraint(equalTo: menuDescription.leadingAnchor),
+            
+            deliveryInfoTitle.topAnchor.constraint(equalTo: menuDescription.bottomAnchor, constant: 4),
+            deliveryInfoTitle.leadingAnchor.constraint(equalTo: menuDescription.leadingAnchor),
+            
+            salePrice.topAnchor.constraint(equalTo: priceTitle.topAnchor),
+            salePrice.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -8),
+            
+            originalPrice.topAnchor.constraint(equalTo: salePrice.topAnchor),
+            originalPrice.trailingAnchor.constraint(equalTo: salePrice.leadingAnchor, constant: -4),
+            
+            savedMoney.topAnchor.constraint(equalTo: savedMoneyTitle.topAnchor),
+            savedMoney.leadingAnchor.constraint(equalTo: savedMoneyTitle.trailingAnchor, constant: 4),
+            
+            deliveryMoney.topAnchor.constraint(equalTo: deliveryMoneyTitle.topAnchor),
+            deliveryMoney.leadingAnchor.constraint(equalTo: deliveryMoneyTitle.trailingAnchor, constant: 4),
+            
+            deliveryInfo.topAnchor.constraint(equalTo: deliveryInfoTitle.topAnchor),
+            deliveryInfo.leadingAnchor.constraint(equalTo: deliveryInfoTitle.trailingAnchor, constant: 4),
+            
+            detailImageStack.topAnchor.constraint(equalTo: deliveryInfoTitle.bottomAnchor, constant: 20),
+            detailImageStack.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            detailImageStack.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            detailImageStack.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+            
+            orderButton.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            orderButton.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            orderButton.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -20),
+            orderButton.heightAnchor.constraint(equalTo: self.view.heightAnchor, multiplier: 0.1)
+            
+        ]
+        
+        constraints.forEach { $0.isActive = true }
     }
     
 }

--- a/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
+++ b/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
@@ -1,0 +1,17 @@
+//
+//  DetailViewController.swift
+//  SideDishApp
+//
+//  Created by delma on 2020/04/26.
+//  Copyright © 2020 delma. All rights reserved.
+//
+
+import UIKit
+
+class DetailViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+}

--- a/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
+++ b/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
@@ -105,8 +105,7 @@ class DetailViewController: UIViewController {
     //MARK:- functions
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationController?.setNavigationBarHidden(false, animated: false)
-        
+
         addSubViews()
         configureScrollViewConstraints()
         configureStackViewConstraints()
@@ -114,7 +113,8 @@ class DetailViewController: UIViewController {
         configureUsecase(menuHash)
         width = self.view.frame.width
         height = self.view.frame.height
-        
+
+        self.navigationController?.setNavigationBarHidden(false, animated: false)
         orderButton.addTarget(self, action: #selector(pressOrderButton(button:)), for: .touchUpInside)
     }
     
@@ -223,7 +223,7 @@ class DetailViewController: UIViewController {
     }
     
     private func configureUsecase(_ menuHash: String) {
-        NetworkUseCase.makeMenuDetail(with: MenuViewController.networkManager, menuHash: "") { data in
+        NetworkUseCase.makeMenuDetail(with: MenuViewController.networkManager, menuHash: menuHash) { data in
             self.menuDetail = data
             DispatchQueue.main.async {
                 guard let menuDetail = self.menuDetail else { return }
@@ -277,17 +277,23 @@ class DetailViewController: UIViewController {
     }
     
     @objc func pressOrderButton(button: UIButton) {
-        let alert = makeOrderCheckAlert()
-        present(alert, animated: true)
+        let noStockAlert = makeAlert(title: "재고없음", message: "재고가 없어 주문이 취소되었습니다", insideAlert: nil) {
+            self.navigationController?.popViewController(animated: true)
+        }
+        let defaultAlert = makeAlert(title: "주문", message: "주문하시겠습니까?", insideAlert: noStockAlert) { }
+        present(defaultAlert, animated: true)
     }
     
-    private func makeOrderCheckAlert() -> UIAlertController {
-        let alert = UIAlertController(title: "주문", message: "주문하시겠습니까?", preferredStyle: .alert)
-        let ok = UIAlertAction(title: "네", style: .default) 
+    private func makeAlert(title: String, message: String, insideAlert: UIAlertController?, handler: @escaping () -> ()) -> UIAlertController {
+        let defaultAlert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let ok = UIAlertAction(title: "네", style: .default) { ok in
+            if let alert = insideAlert { self.present(alert, animated: true) }
+            handler()
+        }
         let cancel = UIAlertAction(title: "아니오", style: .cancel)
         
-        alert.addAction(ok)
-        alert.addAction(cancel)
-        return alert
+        defaultAlert.addAction(ok)
+        defaultAlert.addAction(cancel)
+        return defaultAlert
     }
 }

--- a/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
+++ b/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
@@ -59,10 +59,10 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
     
     private let pageControl = UIPageControl()
     
-    private let priceTitle = ContentsTitleLabel()
-    private let savedMoneyTitle = ContentsTitleLabel()
-    private let deliveryMoneyTitle = ContentsTitleLabel()
-    private let deliveryInfoTitle = ContentsTitleLabel()
+    private let priceTitle = ContentsTitleLabel(text: "가격")
+    private let savedMoneyTitle = ContentsTitleLabel(text: "적립금")
+    private let deliveryMoneyTitle = ContentsTitleLabel(text: "배송비")
+    private let deliveryInfoTitle = ContentsTitleLabel(text: "배송정보")
     
     private let originalPrice = DescriptionLabel()
     private let savedMoney = DescriptionLabel()
@@ -106,6 +106,9 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         addSubViews()
         configureConstraints()
         thumbnailScrollView.delegate = self
+        
+        configureUsecase(menuHash)
+        
     }
     
     func makeImageView(image: UIImage) -> UIImageView {
@@ -163,13 +166,13 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
             priceTitle.topAnchor.constraint(equalTo: menuDescription.bottomAnchor, constant: 8),
             priceTitle.leadingAnchor.constraint(equalTo: menuDescription.leadingAnchor),
             
-            savedMoneyTitle.topAnchor.constraint(equalTo: menuDescription.bottomAnchor, constant: 4),
+            savedMoneyTitle.topAnchor.constraint(equalTo: priceTitle.bottomAnchor, constant: 4),
             savedMoneyTitle.leadingAnchor.constraint(equalTo: menuDescription.leadingAnchor),
             
-            deliveryMoneyTitle.topAnchor.constraint(equalTo: menuDescription.bottomAnchor, constant: 4),
+            deliveryMoneyTitle.topAnchor.constraint(equalTo: savedMoneyTitle.bottomAnchor, constant: 4),
             deliveryMoneyTitle.leadingAnchor.constraint(equalTo: menuDescription.leadingAnchor),
             
-            deliveryInfoTitle.topAnchor.constraint(equalTo: menuDescription.bottomAnchor, constant: 4),
+            deliveryInfoTitle.topAnchor.constraint(equalTo: deliveryMoneyTitle.bottomAnchor, constant: 4),
             deliveryInfoTitle.leadingAnchor.constraint(equalTo: menuDescription.leadingAnchor),
             
             salePrice.topAnchor.constraint(equalTo: priceTitle.topAnchor),
@@ -198,16 +201,29 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
             orderButton.heightAnchor.constraint(equalTo: self.view.heightAnchor, multiplier: 0.1)
             
         ]
-        
         constraints.forEach { $0.isActive = true }
     }
     
     private func configureUsecase(_ menuHash: String) {
-        NetworkUseCase.makeMenuDetail(with: MenuViewController.networkManager, menuHash: menuHash) { data in
+        NetworkUseCase.makeMenuDetail(with: MenuViewController.networkManager, menuHash: "") { data in
             self.menuDetail = data
-            self.pageControl.numberOfPages = self.menuDetail!.thumb_images.count
-
+            DispatchQueue.main.async {
+                self.pageControl.numberOfPages = self.menuDetail!.thumb_images.count
+            guard let menuDetail = self.menuDetail else { return }
+            self.configureData(menuDetail)
+            }
+            
         }
+    }
+    
+    private func configureData(_ menuDetail: MenuDetail) {
+        menuTitle.text = menuDetail.title
+        menuDescription.text = menuDetail.description
+        originalPrice.text = menuDetail.originPrice
+        salePrice.text = menuDetail.salePrice
+        savedMoney.text = menuDetail.point
+        deliveryMoney.text = menuDetail.delivery_fee
+        deliveryInfo.text = menuDetail.delivery_info
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {

--- a/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
+++ b/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
@@ -13,7 +13,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
     //MARK:- properties
     var menuHash = ""
     private var menuDetail: MenuDetail?
-              
+    
     private lazy var wholeScrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
@@ -21,6 +21,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         scrollView.showsVerticalScrollIndicator = true
         scrollView.contentSize = self.view.bounds.size
         scrollView.autoresizingMask = .flexibleHeight
+        scrollView.showsVerticalScrollIndicator = true
         return scrollView
     }()
     
@@ -28,6 +29,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         let scrollView = UIScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.showsHorizontalScrollIndicator = true
+        scrollView.showsVerticalScrollIndicator = false
         scrollView.isPagingEnabled = true
         scrollView.alwaysBounceVertical = false
         return scrollView
@@ -46,7 +48,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
     private let menuTitle: UILabel = {
         let label = UILabel()
         label.textColor = .black
-        label.font = UIFont.boldSystemFont(ofSize: 17.0)
+        label.font = UIFont.boldSystemFont(ofSize: 19.0)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -93,7 +95,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         let button = UIButton()
         button.setTitle("주문하기", for: .normal)
         button.setTitleColor(.white, for: .normal)
-        button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 18)
+        button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 20)
         button.titleLabel?.textAlignment = .center
         button.backgroundColor = #colorLiteral(red: 0.4551282529, green: 0.9278236041, blue: 0.8855857598, alpha: 1)
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -106,16 +108,18 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         self.navigationController?.setNavigationBarHidden(false, animated: false)
         
         addSubViews()
-        configureConstraints()
+        configureScrollViewConstraints()
+        configureStackViewConstraints()
+        configureElementsConstraints()
         thumbnailScrollView.delegate = self
         wholeScrollView.delegate = self
         configureUsecase(menuHash)
     }
     
     func makeImageView(image: UIImage) -> UIImageView {
-        let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: self.view.frame.width, height: self.view.frame.height/3))
+        let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: self.view.frame.width, height: 300))
         imageView.image = image
-        imageView.contentMode = .scaleToFill
+        imageView.contentMode = .scaleAspectFit
         return imageView
     }
     
@@ -143,24 +147,43 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         self.view.addSubview(orderButton)
     }
     
-    private func configureConstraints() {
+    private func configureScrollViewConstraints() {
         let constraints = [
             wholeScrollView.topAnchor.constraint(equalTo: self.view.topAnchor),
             wholeScrollView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
             wholeScrollView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
             wholeScrollView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
-                        
+            
+            wholeScrollView.contentLayoutGuide.topAnchor.constraint(equalTo: self.view.topAnchor),
+            wholeScrollView.contentLayoutGuide.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            wholeScrollView.contentLayoutGuide.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            
             thumbnailScrollView.topAnchor.constraint(equalTo: wholeScrollView.topAnchor),
             thumbnailScrollView.leadingAnchor.constraint(equalTo: wholeScrollView.leadingAnchor),
             thumbnailScrollView.trailingAnchor.constraint(equalTo: wholeScrollView.trailingAnchor),
-            thumbnailScrollView.heightAnchor.constraint(equalTo: self.view.heightAnchor, multiplier: 0.3),
-            thumbnailScrollView.contentLayoutGuide.widthAnchor.constraint(equalTo: thumbnailStackView.widthAnchor),
+            thumbnailScrollView.heightAnchor.constraint(equalToConstant: self.view.frame.size.height/3),
             
-            thumbnailStackView.topAnchor.constraint(equalTo: self.view.topAnchor),
+        ]
+        constraints.forEach { $0.isActive = true }
+    }
+    
+    private func configureStackViewConstraints() {
+        let constraints = [
+            thumbnailStackView.topAnchor.constraint(equalTo: thumbnailScrollView.topAnchor),
             thumbnailStackView.leadingAnchor.constraint(equalTo: thumbnailScrollView.leadingAnchor),
             thumbnailStackView.trailingAnchor.constraint(equalTo: thumbnailScrollView.trailingAnchor),
             thumbnailStackView.bottomAnchor.constraint(equalTo: thumbnailScrollView.bottomAnchor),
             
+            detailImageStack.topAnchor.constraint(equalTo: deliveryInfoTitle.bottomAnchor, constant: 10),
+            detailImageStack.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            detailImageStack.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            detailImageStack.bottomAnchor.constraint(equalTo: wholeScrollView.bottomAnchor),
+        ]
+        constraints.forEach { $0.isActive = true }
+    }
+    
+    private func configureElementsConstraints() {
+        let constraints = [
             menuTitle.topAnchor.constraint(equalTo: thumbnailScrollView.bottomAnchor, constant: 20),
             menuTitle.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 20),
             
@@ -195,16 +218,10 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
             deliveryInfo.leadingAnchor.constraint(equalTo: deliveryInfoTitle.trailingAnchor, constant: 10),
             deliveryInfo.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -20),
             
-            detailImageStack.topAnchor.constraint(equalTo: deliveryInfoTitle.bottomAnchor, constant: 20),
-            detailImageStack.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
-            detailImageStack.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
-            detailImageStack.bottomAnchor.constraint(equalTo: wholeScrollView.bottomAnchor),
-            
             orderButton.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
             orderButton.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
             orderButton.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -20),
             orderButton.heightAnchor.constraint(equalTo: self.view.heightAnchor, multiplier: 0.08)
-            
         ]
         constraints.forEach { $0.isActive = true }
     }

--- a/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
+++ b/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
@@ -13,8 +13,18 @@ class DetailViewController: UIViewController {
     //MARK:- properties
     var menuHash = ""
     private var menuDetail: MenuDetail?
-    var width: CGFloat = 0
-    var height: CGFloat = 0
+    private var width: CGFloat = 0
+    private var height: CGFloat = 0
+    
+    private let priceTitle = ContentsTitleLabel(text: "가격")
+    private let savedMoneyTitle = ContentsTitleLabel(text: "적립금")
+    private let deliveryMoneyTitle = ContentsTitleLabel(text: "배송비")
+    private let deliveryInfoTitle = ContentsTitleLabel(text: "배송정보")
+    
+    private let originalPrice = DescriptionLabel()
+    private let savedMoney = DescriptionLabel()
+    private let deliveryMoney = DescriptionLabel()
+    private let deliveryInfo = DescriptionLabel()
     
     private lazy var wholeScrollView: UIScrollView = {
         let scrollView = UIScrollView()
@@ -63,18 +73,6 @@ class DetailViewController: UIViewController {
         return label
     }()
     
-    private let pageControl = UIPageControl()
-    
-    private let priceTitle = ContentsTitleLabel(text: "가격")
-    private let savedMoneyTitle = ContentsTitleLabel(text: "적립금")
-    private let deliveryMoneyTitle = ContentsTitleLabel(text: "배송비")
-    private let deliveryInfoTitle = ContentsTitleLabel(text: "배송정보")
-    
-    private let originalPrice = DescriptionLabel()
-    private let savedMoney = DescriptionLabel()
-    private let deliveryMoney = DescriptionLabel()
-    private let deliveryInfo = DescriptionLabel()
-    
     private let salePrice: UILabel = {
         let label = UILabel()
         label.font = UIFont.boldSystemFont(ofSize: 18)
@@ -116,6 +114,8 @@ class DetailViewController: UIViewController {
         configureUsecase(menuHash)
         width = self.view.frame.width
         height = self.view.frame.height
+        
+        orderButton.addTarget(self, action: #selector(pressOrderButton(button:)), for: .touchUpInside)
     }
     
     private func addSubViews() {
@@ -226,11 +226,9 @@ class DetailViewController: UIViewController {
         NetworkUseCase.makeMenuDetail(with: MenuViewController.networkManager, menuHash: "") { data in
             self.menuDetail = data
             DispatchQueue.main.async {
-                self.pageControl.numberOfPages = self.menuDetail!.thumb_images.count
                 guard let menuDetail = self.menuDetail else { return }
                 self.configureData(menuDetail)
             }
-            
         }
     }
     
@@ -262,7 +260,7 @@ class DetailViewController: UIViewController {
         }
     }
     
-    func makeImageView(image: UIImage) -> UIImageView {
+    private func makeImageView(image: UIImage) -> UIImageView {
         let imageView = UIImageView()
         imageView.image = image
         return imageView
@@ -278,5 +276,18 @@ class DetailViewController: UIViewController {
         stackView.addArrangedSubview(subView)
     }
     
+    @objc func pressOrderButton(button: UIButton) {
+        let alert = makeOrderCheckAlert()
+        present(alert, animated: true)
+    }
     
+    private func makeOrderCheckAlert() -> UIAlertController {
+        let alert = UIAlertController(title: "주문", message: "주문하시겠습니까?", preferredStyle: .alert)
+        let ok = UIAlertAction(title: "네", style: .default) 
+        let cancel = UIAlertAction(title: "아니오", style: .cancel)
+        
+        alert.addAction(ok)
+        alert.addAction(cancel)
+        return alert
+    }
 }

--- a/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
+++ b/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
@@ -177,17 +177,17 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
             salePrice.topAnchor.constraint(equalTo: priceTitle.topAnchor),
             salePrice.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -20),
             
-            originalPrice.topAnchor.constraint(equalTo: salePrice.topAnchor),
+            originalPrice.bottomAnchor.constraint(equalTo: salePrice.bottomAnchor),
             originalPrice.trailingAnchor.constraint(equalTo: salePrice.leadingAnchor, constant: -4),
             
             savedMoney.topAnchor.constraint(equalTo: savedMoneyTitle.topAnchor),
-            savedMoney.leadingAnchor.constraint(equalTo: savedMoneyTitle.trailingAnchor, constant: 4),
+            savedMoney.leadingAnchor.constraint(equalTo: deliveryInfo.leadingAnchor, constant: 4),
             
             deliveryMoney.topAnchor.constraint(equalTo: deliveryMoneyTitle.topAnchor),
-            deliveryMoney.leadingAnchor.constraint(equalTo: deliveryMoneyTitle.trailingAnchor, constant: 4),
+            deliveryMoney.leadingAnchor.constraint(equalTo: deliveryInfo.leadingAnchor, constant: 4),
             
             deliveryInfo.topAnchor.constraint(equalTo: deliveryInfoTitle.topAnchor),
-            deliveryInfo.leadingAnchor.constraint(equalTo: deliveryInfoTitle.trailingAnchor, constant: 4),
+            deliveryInfo.leadingAnchor.constraint(equalTo: deliveryInfoTitle.trailingAnchor, constant: 10),
             deliveryInfo.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -20),
             
             detailImageStack.topAnchor.constraint(equalTo: deliveryInfoTitle.bottomAnchor, constant: 20),
@@ -224,23 +224,28 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         savedMoney.text = menuDetail.point
         deliveryMoney.text = menuDetail.delivery_fee
         deliveryInfo.text = menuDetail.delivery_info
-        loadImage(urlStrings: menuDetail.thumb_images)
+        loadImage(urlStrings: menuDetail.thumb_images, to: self.thumbnailStackView)
+        loadImage(urlStrings: menuDetail.detail_section, to: self.detailImageStack)
     }
     
-    private func loadImage(urlStrings: [String]) {
+    private func loadImage(urlStrings: [String], to stackView: UIStackView) {
         urlStrings.forEach { url in
             ImageLoader.shared.load(urlString: url) { result in
                 switch result {
                 case .success(let data):
                     DispatchQueue.main.async {
                         let imageView = self.makeImageView(image: UIImage(data: data)!)
-                        self.thumbnailStackView.addArrangedSubview(imageView)
+                        self.addArrangedSubview(to: stackView, subView: imageView)
                     }
                 case .failure(let error):
                     print(error)
                 }
             }
         }
+    }
+    
+    private func addArrangedSubview(to stackView: UIStackView, subView: UIView) {
+        stackView.addArrangedSubview(subView)
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {

--- a/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
+++ b/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
@@ -13,7 +13,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
     //MARK:- properties
     var menuHash = ""
     private var menuDetail: MenuDetail?
-    
+              
     private let wholeScrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
@@ -101,14 +101,13 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
     //MARK:- functions
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationController?.navigationBar.isHidden = false
+        self.navigationController?.setNavigationBarHidden(false, animated: false)
         
         addSubViews()
         configureConstraints()
         thumbnailScrollView.delegate = self
         
         configureUsecase(menuHash)
-        
     }
     
     func makeImageView(image: UIImage) -> UIImageView {
@@ -157,13 +156,13 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
             thumbnailStackView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
             thumbnailStackView.bottomAnchor.constraint(equalTo: thumbnailScrollView.bottomAnchor),
             
-            menuTitle.topAnchor.constraint(equalTo: thumbnailScrollView.bottomAnchor, constant: 8),
-            menuTitle.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 8),
+            menuTitle.topAnchor.constraint(equalTo: thumbnailScrollView.bottomAnchor, constant: 20),
+            menuTitle.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 20),
             
             menuDescription.topAnchor.constraint(equalTo: menuTitle.bottomAnchor, constant: 4),
             menuDescription.leadingAnchor.constraint(equalTo: menuTitle.leadingAnchor),
             
-            priceTitle.topAnchor.constraint(equalTo: menuDescription.bottomAnchor, constant: 8),
+            priceTitle.topAnchor.constraint(equalTo: menuDescription.bottomAnchor, constant: 15),
             priceTitle.leadingAnchor.constraint(equalTo: menuDescription.leadingAnchor),
             
             savedMoneyTitle.topAnchor.constraint(equalTo: priceTitle.bottomAnchor, constant: 4),
@@ -176,7 +175,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
             deliveryInfoTitle.leadingAnchor.constraint(equalTo: menuDescription.leadingAnchor),
             
             salePrice.topAnchor.constraint(equalTo: priceTitle.topAnchor),
-            salePrice.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -8),
+            salePrice.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -20),
             
             originalPrice.topAnchor.constraint(equalTo: salePrice.topAnchor),
             originalPrice.trailingAnchor.constraint(equalTo: salePrice.leadingAnchor, constant: -4),
@@ -189,6 +188,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
             
             deliveryInfo.topAnchor.constraint(equalTo: deliveryInfoTitle.topAnchor),
             deliveryInfo.leadingAnchor.constraint(equalTo: deliveryInfoTitle.trailingAnchor, constant: 4),
+            deliveryInfo.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -20),
             
             detailImageStack.topAnchor.constraint(equalTo: deliveryInfoTitle.bottomAnchor, constant: 20),
             detailImageStack.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
@@ -198,7 +198,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
             orderButton.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
             orderButton.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
             orderButton.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -20),
-            orderButton.heightAnchor.constraint(equalTo: self.view.heightAnchor, multiplier: 0.1)
+            orderButton.heightAnchor.constraint(equalTo: self.view.heightAnchor, multiplier: 0.08)
             
         ]
         constraints.forEach { $0.isActive = true }
@@ -232,8 +232,10 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
             ImageLoader.shared.load(urlString: url) { result in
                 switch result {
                 case .success(let data):
-                   let imageView = self.makeImageView(image: UIImage(data: data)!)
-                   self.thumbnailStackView.addArrangedSubview(imageView)
+                    DispatchQueue.main.async {
+                        let imageView = self.makeImageView(image: UIImage(data: data)!)
+                        self.thumbnailStackView.addArrangedSubview(imageView)
+                    }
                 case .failure(let error):
                     print(error)
                 }

--- a/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
+++ b/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
@@ -14,11 +14,13 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
     var menuHash = ""
     private var menuDetail: MenuDetail?
               
-    private let wholeScrollView: UIScrollView = {
+    private lazy var wholeScrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.scrollsToTop = true
         scrollView.showsVerticalScrollIndicator = true
+        scrollView.contentSize = self.view.bounds.size
+        scrollView.autoresizingMask = .flexibleHeight
         return scrollView
     }()
     
@@ -106,21 +108,23 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         addSubViews()
         configureConstraints()
         thumbnailScrollView.delegate = self
-        
+        wholeScrollView.delegate = self
         configureUsecase(menuHash)
     }
     
     func makeImageView(image: UIImage) -> UIImageView {
-        let imageView = UIImageView()
+        let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: self.view.frame.width, height: self.view.frame.height/3))
         imageView.image = image
+        imageView.contentMode = .scaleToFill
         return imageView
     }
     
     private func addSubViews() {
         self.view.addSubview(wholeScrollView)
-        wholeScrollView.addSubview(thumbnailScrollView)
-        thumbnailScrollView.addSubview(thumbnailStackView)
         
+        wholeScrollView.addSubview(thumbnailScrollView)
+        
+        thumbnailScrollView.addSubview(thumbnailStackView)
         wholeScrollView.addSubview(menuTitle)
         wholeScrollView.addSubview(menuDescription)
         
@@ -145,15 +149,16 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
             wholeScrollView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
             wholeScrollView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
             wholeScrollView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
-            
-            thumbnailScrollView.topAnchor.constraint(equalTo: self.view.topAnchor),
-            thumbnailScrollView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
-            thumbnailScrollView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+                        
+            thumbnailScrollView.topAnchor.constraint(equalTo: wholeScrollView.topAnchor),
+            thumbnailScrollView.leadingAnchor.constraint(equalTo: wholeScrollView.leadingAnchor),
+            thumbnailScrollView.trailingAnchor.constraint(equalTo: wholeScrollView.trailingAnchor),
             thumbnailScrollView.heightAnchor.constraint(equalTo: self.view.heightAnchor, multiplier: 0.3),
+            thumbnailScrollView.contentLayoutGuide.widthAnchor.constraint(equalTo: thumbnailStackView.widthAnchor),
             
             thumbnailStackView.topAnchor.constraint(equalTo: self.view.topAnchor),
-            thumbnailStackView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
-            thumbnailStackView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            thumbnailStackView.leadingAnchor.constraint(equalTo: thumbnailScrollView.leadingAnchor),
+            thumbnailStackView.trailingAnchor.constraint(equalTo: thumbnailScrollView.trailingAnchor),
             thumbnailStackView.bottomAnchor.constraint(equalTo: thumbnailScrollView.bottomAnchor),
             
             menuTitle.topAnchor.constraint(equalTo: thumbnailScrollView.bottomAnchor, constant: 20),
@@ -193,7 +198,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
             detailImageStack.topAnchor.constraint(equalTo: deliveryInfoTitle.bottomAnchor, constant: 20),
             detailImageStack.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
             detailImageStack.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
-            detailImageStack.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+            detailImageStack.bottomAnchor.constraint(equalTo: wholeScrollView.bottomAnchor),
             
             orderButton.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
             orderButton.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),

--- a/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
+++ b/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
@@ -137,7 +137,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         wholeScrollView.addSubview(salePrice)
         
         wholeScrollView.addSubview(detailImageStack)
-        wholeScrollView.addSubview(orderButton)
+        self.view.addSubview(orderButton)
     }
     
     private func configureConstraints() {
@@ -209,8 +209,8 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
             self.menuDetail = data
             DispatchQueue.main.async {
                 self.pageControl.numberOfPages = self.menuDetail!.thumb_images.count
-            guard let menuDetail = self.menuDetail else { return }
-            self.configureData(menuDetail)
+                guard let menuDetail = self.menuDetail else { return }
+                self.configureData(menuDetail)
             }
             
         }
@@ -224,6 +224,21 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         savedMoney.text = menuDetail.point
         deliveryMoney.text = menuDetail.delivery_fee
         deliveryInfo.text = menuDetail.delivery_info
+        loadImage(urlStrings: menuDetail.thumb_images)
+    }
+    
+    private func loadImage(urlStrings: [String]) {
+        urlStrings.forEach { url in
+            ImageLoader.shared.load(urlString: url) { result in
+                switch result {
+                case .success(let data):
+                   let imageView = self.makeImageView(image: UIImage(data: data)!)
+                   self.thumbnailStackView.addArrangedSubview(imageView)
+                case .failure(let error):
+                    print(error)
+                }
+            }
+        }
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {

--- a/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
+++ b/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
@@ -8,9 +8,12 @@
 
 import UIKit
 
-class DetailViewController: UIViewController {
+class DetailViewController: UIViewController, UIScrollViewDelegate {
     
     //MARK:- properties
+    var menuHash = ""
+    private var menuDetail: MenuDetail?
+    
     private let wholeScrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
@@ -23,6 +26,8 @@ class DetailViewController: UIViewController {
         let scrollView = UIScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.showsHorizontalScrollIndicator = true
+        scrollView.isPagingEnabled = true
+        scrollView.alwaysBounceVertical = false
         return scrollView
     }()
     
@@ -51,6 +56,8 @@ class DetailViewController: UIViewController {
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
+    
+    private let pageControl = UIPageControl()
     
     private let priceTitle = ContentsTitleLabel()
     private let savedMoneyTitle = ContentsTitleLabel()
@@ -98,6 +105,7 @@ class DetailViewController: UIViewController {
         
         addSubViews()
         configureConstraints()
+        thumbnailScrollView.delegate = self
     }
     
     func makeImageView(image: UIImage) -> UIImageView {
@@ -193,5 +201,18 @@ class DetailViewController: UIViewController {
         
         constraints.forEach { $0.isActive = true }
     }
+    
+    private func configureUsecase(_ menuHash: String) {
+        NetworkUseCase.makeMenuDetail(with: MenuViewController.networkManager, menuHash: menuHash) { data in
+            self.menuDetail = data
+            self.pageControl.numberOfPages = self.menuDetail!.thumb_images.count
+
+        }
+    }
+    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        pageControl.currentPage = Int(floor(thumbnailScrollView.contentOffset.x / UIScreen.main.bounds.width))
+    }
+    
     
 }

--- a/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
+++ b/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
@@ -8,11 +8,13 @@
 
 import UIKit
 
-class DetailViewController: UIViewController, UIScrollViewDelegate {
+class DetailViewController: UIViewController {
     
     //MARK:- properties
     var menuHash = ""
     private var menuDetail: MenuDetail?
+    var width: CGFloat = 0
+    var height: CGFloat = 0
     
     private lazy var wholeScrollView: UIScrollView = {
         let scrollView = UIScrollView()
@@ -111,16 +113,9 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         configureScrollViewConstraints()
         configureStackViewConstraints()
         configureElementsConstraints()
-        thumbnailScrollView.delegate = self
-        wholeScrollView.delegate = self
         configureUsecase(menuHash)
-    }
-    
-    func makeImageView(image: UIImage) -> UIImageView {
-        let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: self.view.frame.width, height: 300))
-        imageView.image = image
-        imageView.contentMode = .scaleAspectFit
-        return imageView
+        width = self.view.frame.width
+        height = self.view.frame.height
     }
     
     private func addSubViews() {
@@ -152,7 +147,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
             wholeScrollView.topAnchor.constraint(equalTo: self.view.topAnchor),
             wholeScrollView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
             wholeScrollView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
-            wholeScrollView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+            wholeScrollView.bottomAnchor.constraint(equalTo: orderButton.topAnchor),
             
             wholeScrollView.contentLayoutGuide.topAnchor.constraint(equalTo: self.view.topAnchor),
             wholeScrollView.contentLayoutGuide.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
@@ -173,6 +168,7 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
             thumbnailStackView.leadingAnchor.constraint(equalTo: thumbnailScrollView.leadingAnchor),
             thumbnailStackView.trailingAnchor.constraint(equalTo: thumbnailScrollView.trailingAnchor),
             thumbnailStackView.bottomAnchor.constraint(equalTo: thumbnailScrollView.bottomAnchor),
+            thumbnailStackView.heightAnchor.constraint(equalTo: thumbnailScrollView.heightAnchor),
             
             detailImageStack.topAnchor.constraint(equalTo: deliveryInfoTitle.bottomAnchor, constant: 10),
             detailImageStack.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
@@ -266,12 +262,16 @@ class DetailViewController: UIViewController, UIScrollViewDelegate {
         }
     }
     
-    private func addArrangedSubview(to stackView: UIStackView, subView: UIView) {
-        stackView.addArrangedSubview(subView)
+    func makeImageView(image: UIImage) -> UIImageView {
+        let imageView = UIImageView()
+        imageView.image = image
+        return imageView
     }
     
-    func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        pageControl.currentPage = Int(floor(thumbnailScrollView.contentOffset.x / UIScreen.main.bounds.width))
+    private func addArrangedSubview(to stackView: UIStackView, subView: UIImageView) {
+        subView.widthAnchor.constraint(equalToConstant: width).isActive = true
+        subView.heightAnchor.constraint(equalToConstant: height/3).isActive = true
+        stackView.addArrangedSubview(subView)
     }
     
     

--- a/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
+++ b/iOS/SideDishApp/SideDishApp/ViewControllers/DetailViewController.swift
@@ -180,7 +180,7 @@ class DetailViewController: UIViewController {
     
     private func configureElementsConstraints() {
         let constraints = [
-            menuTitle.topAnchor.constraint(equalTo: thumbnailScrollView.bottomAnchor, constant: 20),
+            menuTitle.topAnchor.constraint(equalTo: thumbnailScrollView.bottomAnchor, constant: 30),
             menuTitle.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 20),
             
             menuDescription.topAnchor.constraint(equalTo: menuTitle.bottomAnchor, constant: 4),
@@ -242,18 +242,18 @@ class DetailViewController: UIViewController {
         savedMoney.text = menuDetail.point
         deliveryMoney.text = menuDetail.delivery_fee
         deliveryInfo.text = menuDetail.delivery_info
-        loadImage(urlStrings: menuDetail.thumb_images, to: self.thumbnailStackView)
-        loadImage(urlStrings: menuDetail.detail_section, to: self.detailImageStack)
+        loadImage(urlStrings: menuDetail.thumb_images, to: self.thumbnailStackView, isThumbnail: true)
+        loadImage(urlStrings: menuDetail.detail_section, to: self.detailImageStack, isThumbnail: false)
     }
     
-    private func loadImage(urlStrings: [String], to stackView: UIStackView) {
+    private func loadImage(urlStrings: [String], to stackView: UIStackView, isThumbnail: Bool) {
         urlStrings.forEach { url in
             ImageLoader.shared.load(urlString: url) { result in
                 switch result {
                 case .success(let data):
                     DispatchQueue.main.async {
                         let imageView = self.makeImageView(image: UIImage(data: data)!)
-                        self.addArrangedSubview(to: stackView, subView: imageView)
+                        self.addArrangedSubview(to: stackView, subView: imageView, isThumbnail: isThumbnail)
                     }
                 case .failure(let error):
                     print(error)
@@ -268,9 +268,13 @@ class DetailViewController: UIViewController {
         return imageView
     }
     
-    private func addArrangedSubview(to stackView: UIStackView, subView: UIImageView) {
+    private func addArrangedSubview(to stackView: UIStackView, subView: UIImageView, isThumbnail: Bool) {
+        if isThumbnail {
+            subView.heightAnchor.constraint(equalToConstant: height/3).isActive = true
+        }else {
+            subView.heightAnchor.constraint(equalToConstant: height/3 + 300.0).isActive = true
+        }
         subView.widthAnchor.constraint(equalToConstant: width).isActive = true
-        subView.heightAnchor.constraint(equalToConstant: height/3).isActive = true
         stackView.addArrangedSubview(subView)
     }
     

--- a/iOS/SideDishApp/SideDishApp/ViewControllers/LoginViewController.swift
+++ b/iOS/SideDishApp/SideDishApp/ViewControllers/LoginViewController.swift
@@ -19,7 +19,7 @@ class LoginViewController: UIViewController {
     }
     
     @IBAction func signInGithub(_ sender: UIButton) {
-        guard let menuViewController = self.storyboard?.instantiateViewController(withIdentifier: "MenuViewController") else { return }
+        guard let menuViewController = self.storyboard?.instantiateViewController(withIdentifier: "NavigationViewController") as? UINavigationController else { return }
         self.present(menuViewController, animated: true)
     }
     

--- a/iOS/SideDishApp/SideDishApp/ViewControllers/MenuViewController.swift
+++ b/iOS/SideDishApp/SideDishApp/ViewControllers/MenuViewController.swift
@@ -48,7 +48,8 @@ class MenuViewController: UIViewController, UITableViewDataSource, UITableViewDe
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let detailViewController = self.storyboard?.instantiateViewController(identifier: "DetailViewController") else { return }
+        guard let detailViewController = self.storyboard?.instantiateViewController(identifier: "DetailViewController") as? DetailViewController else { return }
+        detailViewController.menuHash = (allMenus[indexPath.section]?.data[indexPath.row].hash)!
         self.navigationController?.pushViewController(detailViewController, animated: true)
     }
     

--- a/iOS/SideDishApp/SideDishApp/ViewControllers/MenuViewController.swift
+++ b/iOS/SideDishApp/SideDishApp/ViewControllers/MenuViewController.swift
@@ -21,6 +21,12 @@ class MenuViewController: UIViewController, UITableViewDataSource, UITableViewDe
         super.viewDidLoad()
         configureTableView()
         configureUsecase()
+        navigationController?.interactivePopGestureRecognizer?.delegate = nil
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: false)
     }
     
     func numberOfSections(in tableView: UITableView) -> Int {

--- a/iOS/SideDishApp/SideDishApp/ViewControllers/MenuViewController.swift
+++ b/iOS/SideDishApp/SideDishApp/ViewControllers/MenuViewController.swift
@@ -47,6 +47,11 @@ class MenuViewController: UIViewController, UITableViewDataSource, UITableViewDe
         return cell
     }
     
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let detailViewController = self.storyboard?.instantiateViewController(identifier: "DetailViewController") else { return }
+        self.navigationController?.pushViewController(detailViewController, animated: true)
+    }
+    
     func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
         let gesture = SectionHeaderTapGestureRecognizer(target: self, action: #selector(touchedSectionHeader(recognizer:)))
         gesture.index = section

--- a/iOS/SideDishApp/SideDishApp/Views/Components/ContentsTitleLabel.swift
+++ b/iOS/SideDishApp/SideDishApp/Views/Components/ContentsTitleLabel.swift
@@ -1,0 +1,33 @@
+//
+//  ContentsTitleLabel.swift
+//  SideDishApp
+//
+//  Created by delma on 2020/04/26.
+//  Copyright © 2020 delma. All rights reserved.
+//
+
+import UIKit
+
+class ContentsTitleLabel: UILabel {
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configure()
+    }
+
+    func configureData(string: String) {
+        self.text = string
+    }
+    
+    private func configure() {
+        self.textColor = .black
+        self.font = UIFont.boldSystemFont(ofSize: 16)
+        self.translatesAutoresizingMaskIntoConstraints = false
+    }
+
+}

--- a/iOS/SideDishApp/SideDishApp/Views/Components/ContentsTitleLabel.swift
+++ b/iOS/SideDishApp/SideDishApp/Views/Components/ContentsTitleLabel.swift
@@ -9,25 +9,25 @@
 import UIKit
 
 class ContentsTitleLabel: UILabel {
-
+    
+    convenience init(text: String) {
+        self.init()
+        configure(text: text)
+    }
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
-        configure()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        configure()
-    }
-
-    func configureData(string: String) {
-        self.text = string
     }
     
-    private func configure() {
+    private func configure(text: String) {
         self.textColor = .black
         self.font = UIFont.boldSystemFont(ofSize: 16)
+        self.text = text
         self.translatesAutoresizingMaskIntoConstraints = false
     }
-
+    
 }

--- a/iOS/SideDishApp/SideDishApp/Views/Components/DescriptionLabel.swift
+++ b/iOS/SideDishApp/SideDishApp/Views/Components/DescriptionLabel.swift
@@ -20,7 +20,7 @@ class DescriptionLabel: UILabel {
         configure()
     }
 
-    func configureData(string: String) {
+    func configureText(string: String) {
         self.text = string
     }
     

--- a/iOS/SideDishApp/SideDishApp/Views/Components/DescriptionLabel.swift
+++ b/iOS/SideDishApp/SideDishApp/Views/Components/DescriptionLabel.swift
@@ -1,0 +1,33 @@
+//
+//  DescriptionLabel.swift
+//  SideDishApp
+//
+//  Created by delma on 2020/04/26.
+//  Copyright © 2020 delma. All rights reserved.
+//
+
+import UIKit
+
+class DescriptionLabel: UILabel {
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configure()
+    }
+
+    func configureData(string: String) {
+        self.text = string
+    }
+    
+    private func configure() {
+        self.textColor = .lightGray
+        self.font = UIFont.systemFont(ofSize: 14.0)
+        self.translatesAutoresizingMaskIntoConstraints = false
+    }
+    
+}

--- a/iOS/SideDishApp/SideDishApp/Views/Components/MenuTableViewCell.swift
+++ b/iOS/SideDishApp/SideDishApp/Views/Components/MenuTableViewCell.swift
@@ -96,6 +96,7 @@ class MenuTableViewCell: UITableViewCell {
             let label = makeBadgeLabel(badge: badge)
             addArrangedSubview(label: label)
         }
+        loadData(urlString: menu.image)
     }
     
     // MARK:- private functions

--- a/iOS/SideDishApp/SideDishApp/Views/Components/MenuTableViewCell.swift
+++ b/iOS/SideDishApp/SideDishApp/Views/Components/MenuTableViewCell.swift
@@ -102,15 +102,15 @@ class MenuTableViewCell: UITableViewCell {
     // MARK:- private functions
     
     private func loadData(urlString: String) {
-        DispatchQueue.main.async {
-            ImageLoader.shared.load(urlString: urlString) { result in
-                switch result {
-                case .success(let data):
+        ImageLoader.shared.load(urlString: urlString) { result in
+            switch result {
+            case .success(let data):
+                DispatchQueue.main.async {
                     self.menuImage.image = UIImage(data: data)
-                case .failure(let error):
-                    //error handling 필요
-                    print(error)
                 }
+            case .failure(let error):
+                //error handling 필요
+                print(error)
             }
         }
     }


### PR DESCRIPTION
메뉴 상세화면과 기능을 구현했습니다

- 메뉴 목록 화면에서 셀 선택시 해당 셀이 가진 해시 값을 상세화면으로 전달해, 상세화면이 표시되기 전에 서버로 요청해 데이터를 받아오게 했습니다.
- 화면 전환은 네비게이션 방식으로 되도록 했습니다.
- 주문 버튼 선택한 후 재고  갯수를 서버로부터 확인해야하는데, 현재 서버에 재고 갯수가 준비되어있지 않아 임의로 재고가 없다고 하고 이전 화면으로 이동되게끔 했습니다.
- 이전 PR에서 피드백 주신 사항은 꼭 반영해서 다시 PR 하겠습니다